### PR TITLE
Added `get_width` and `get_height` to `ImageSize`

### DIFF
--- a/src/image_size.rs
+++ b/src/image_size.rs
@@ -1,9 +1,21 @@
 
-/// Must be implemented by all images to be used with graphics back-end.
-///
-/// Rust-Graphics only needs to know the size.
+/// Must be implemented by all images to be used with generic texture algorithms.
 pub trait ImageSize {
     /// Get the image size.
     fn get_size(&self) -> (u32, u32);
+
+    /// Gets the image width.
+    #[inline(always)]
+    fn get_width(&self) -> u32 {
+        let (w, _) = self.get_size();
+        w
+    }
+
+    /// Gets the image height.
+    #[inline(always)]
+    fn get_height(&self) -> u32 {
+        let (_, h) = self.get_size();
+        h
+    }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_doc)]
+#![deny(missing_docs)]
 
 //! A library for texture conventions.
 //!


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/texture/issues/8
- Fixed doc comment
- Fixed compiler warning about missing docs
