### PR TITLE
Redesign

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ homepage = "https://github.com/pistondevelopers/texture"
 
 name = "texture"
 path = "src/lib.rs"
-
-[dependencies]
-image = "0.3.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston-texture"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>"
 ]
@@ -17,3 +17,5 @@ homepage = "https://github.com/pistondevelopers/texture"
 name = "texture"
 path = "src/lib.rs"
 
+[dependencies]
+image = "0.3.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,11 @@ pub trait ImageSize {
 
 /// Texture creation parameters.
 pub struct TextureSettings {
+    // Whether to convert gamma, treated as sRGB color space
     convert_gamma: bool,
-    /// Compress on GPU.
+    // Compress on GPU.
     compress: bool,
-    /// Generate mipmap chain.
+    // Generate mipmap chain.
     generate_mipmap: bool,
 }
 
@@ -43,7 +44,7 @@ impl TextureSettings {
         }
     }
 
-    /// Gets wheter to convert gamma, treated as sRGB color space.
+    /// Gets whether to convert gamma, treated as sRGB color space.
     pub fn get_convert_gamma(&self) -> bool { self.convert_gamma }
     /// Sets convert gamma.
     pub fn set_convert_gamma(&mut self, val: bool) { self.convert_gamma = val; }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,31 +128,3 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
         channels: u8
     ) -> TextureResult<()>;
 }
-
-/// Interface for device independent backends.
-pub trait Texture: TextureWithFactory<()> + Sized {
-    /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
-    #[inline(always)]
-    fn from_memory<S: Into<[u32; 2]>>(
-        memory: &[u8],
-        size: S,
-        channels: u8,
-        settings: &TextureSettings
-    ) -> TextureResult<Self> {
-        TextureWithFactory::from_memory(&mut (), memory, size, channels, settings)
-    }
-
-    /// Update texture from memory buffer. Supports only RGBA and alpha channels images.
-    #[inline(always)]
-    fn update_from_memory<S: Into<[u32; 2]>>(
-        &mut self,
-        memory: &[u8],
-        size: S,
-        channels: u8
-    ) -> TextureResult<()> {
-        TextureWithFactory::update_from_memory(
-            self, &mut (), memory, size, channels)
-    }
-}
-
-impl<T: TextureWithFactory<()>> Texture for T {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,12 @@
 
 //! A library for texture conventions.
 
+extern crate image;
+
+use std::fmt::{ Display, Formatter, Error };
+use std::path::Path;
+use image::{ RgbaImage, ImageError, DynamicImage };
+
 /// Implemented by all images to be used with generic algorithms.
 pub trait ImageSize {
     /// Get the image size.
@@ -22,3 +28,158 @@ pub trait ImageSize {
     }
 }
 
+/// Result of an texture creating/updating process.
+pub type TextureResult<T> = Result<T, TextureError>;
+
+/// An enumeration of Texture and TextureWithDevice errors.
+#[derive(Debug)]
+pub enum TextureError {
+    /// The image openinng error.
+    ImageError(ImageError),
+
+    /// The channels number error.
+    InvalidNumberOfChannels(usize),
+
+    /// The error in backend factory.
+    FactoryError(String)
+}
+
+impl From<ImageError> for TextureError {
+    fn from(e: ImageError) -> Self {
+        TextureError::ImageError(e)
+    }
+}
+
+impl Display for TextureError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match *self {
+            TextureError::ImageError(ref e) => e.fmt(f),
+            TextureError::InvalidNumberOfChannels(n) =>
+                format!("Invalid number of channels: {}, expected 1 or 4", n).fmt(f),
+            TextureError::FactoryError(ref s) => s.fmt(f)
+        }
+    }
+}
+
+/// Unified interface creating/updating texture over backends.
+pub trait TextureWithFactory: ImageSize + Sized {
+    /// Texture factory.
+    type Factory;
+
+    /// Create texture from path.
+    #[inline(always)]
+    fn from_path<P: AsRef<Path>>(
+        device: &mut Self::Factory,
+        path: P
+    ) -> TextureResult<Self> {
+        let image = try!(image::open(path));
+        let image = match image {
+            DynamicImage::ImageRgba8(image) => image,
+            image => image.to_rgba()
+        };
+        Self::from_image(device, &image)
+    }
+
+    /// Create texture from RGBA image.
+    #[inline(always)]
+    fn from_image(
+        device: &mut Self::Factory,
+        image: &RgbaImage
+    ) -> TextureResult<Self> {
+        let width = image.width() as usize;
+        Self::from_memory(device, image, width, 4)
+    }
+
+    /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
+    fn from_memory(
+        device: &mut Self::Factory,
+        memory: &[u8],
+        width: usize,
+        channels: usize
+    ) -> TextureResult<Self>;
+
+    /// Update texture from path.
+    #[inline(always)]
+    fn update_from_path<P: AsRef<Path>>(
+        &mut self,
+        device: &mut Self::Factory,
+        path: P
+    ) -> TextureResult<()> {
+        let image = try!(image::open(path));
+        let image = match image {
+            DynamicImage::ImageRgba8(image) => image,
+            image => image.to_rgba()
+        };
+        self.update_from_image(device, &image)
+    }
+
+    /// Update texture from RGBA image.
+    #[inline(always)]
+    fn update_from_image(
+        &mut self,
+        device: &mut Self::Factory,
+        image: &RgbaImage
+    ) -> TextureResult<()> {
+        let width = image.width() as usize;
+        self.update_from_memory(device, image, width, 4)
+    }
+
+    /// Update texture from memory buffer. Supported only RGBA and alpha channels images.
+    fn update_from_memory(
+        &mut self,
+        device: &mut Self::Factory,
+        memory: &[u8],
+        width: usize,
+        channels: usize
+    ) -> TextureResult<()>;
+}
+
+/// Interface for device independent backends.
+pub trait Texture: TextureWithFactory<Factory = ()> + Sized {
+    /// Create texture from path.
+    #[inline(always)]
+    fn from_path<P: AsRef<Path>>(path: P) -> TextureResult<Self> {
+        TextureWithFactory::from_path(&mut (), path)
+    }
+
+    /// Create texture from RGBA image.
+    #[inline(always)]
+    fn from_image(image: &RgbaImage) -> TextureResult<Self> {
+        TextureWithFactory::from_image(&mut (), image)
+    }
+
+    /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
+    #[inline(always)]
+    fn from_memory(
+        memory: &[u8],
+        width: usize,
+        channels: usize
+    ) -> TextureResult<Self> {
+        TextureWithFactory::from_memory(&mut (), memory, width, channels)
+    }
+
+    /// Update texture from path.
+    #[inline(always)]
+    fn update_from_path<P: AsRef<Path>>(&mut self, path: P) -> TextureResult<()> {
+        TextureWithFactory::update_from_path(self, &mut (), path)
+    }
+
+    /// Update texture from RGBA image.
+    #[inline(always)]
+    fn update_from_image(&mut self, image: &RgbaImage) -> TextureResult<()> {
+        TextureWithFactory::update_from_image(self, &mut (), image)
+    }
+
+    /// Update texture from memory buffer. Supports only RGBA and alpha channels images.
+    #[inline(always)]
+    fn update_from_memory(
+        &mut self,
+        memory: &[u8],
+        width: usize,
+        channels: usize
+    ) -> TextureResult<()> {
+        TextureWithFactory::update_from_memory(self, &mut (), memory, width, channels)
+    }
+}
+
+impl<T: TextureWithFactory<Factory = ()>> Texture for T {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,14 +127,12 @@ impl Display for TextureError {
 }
 
 /// Unified interface creating/updating texture over backends.
-pub trait TextureWithFactory: ImageSize + Sized {
-    /// Texture factory.
-    type Factory;
+pub trait TextureWithFactory<F>: ImageSize + Sized {
 
     /// Create texture from path.
     #[inline(always)]
     fn from_path<P: AsRef<Path>>(
-        device: &mut Self::Factory,
+        device: &mut F,
         path: P,
         settings: &TextureSettings
     ) -> TextureResult<Self> {
@@ -149,7 +147,7 @@ pub trait TextureWithFactory: ImageSize + Sized {
     /// Create texture from RGBA image.
     #[inline(always)]
     fn from_image(
-        device: &mut Self::Factory,
+        device: &mut F,
         image: &RgbaImage,
         settings: &TextureSettings
     ) -> TextureResult<Self> {
@@ -159,7 +157,7 @@ pub trait TextureWithFactory: ImageSize + Sized {
 
     /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
     fn from_memory(
-        device: &mut Self::Factory,
+        device: &mut F,
         memory: &[u8],
         width: usize,
         channels: usize,
@@ -170,7 +168,7 @@ pub trait TextureWithFactory: ImageSize + Sized {
     #[inline(always)]
     fn update_from_path<P: AsRef<Path>>(
         &mut self,
-        device: &mut Self::Factory,
+        device: &mut F,
         path: P
     ) -> TextureResult<()> {
         let image = try!(image::open(path));
@@ -185,7 +183,7 @@ pub trait TextureWithFactory: ImageSize + Sized {
     #[inline(always)]
     fn update_from_image(
         &mut self,
-        device: &mut Self::Factory,
+        device: &mut F,
         image: &RgbaImage
     ) -> TextureResult<()> {
         let width = image.width() as usize;
@@ -195,7 +193,7 @@ pub trait TextureWithFactory: ImageSize + Sized {
     /// Update texture from memory buffer. Supported only RGBA and alpha channels images.
     fn update_from_memory(
         &mut self,
-        device: &mut Self::Factory,
+        device: &mut F,
         memory: &[u8],
         width: usize,
         channels: usize
@@ -203,7 +201,7 @@ pub trait TextureWithFactory: ImageSize + Sized {
 }
 
 /// Interface for device independent backends.
-pub trait Texture: TextureWithFactory<Factory = ()> + Sized {
+pub trait Texture: TextureWithFactory<()> + Sized {
     /// Create texture from path.
     #[inline(always)]
     fn from_path<P: AsRef<Path>>(
@@ -257,4 +255,4 @@ pub trait Texture: TextureWithFactory<Factory = ()> + Sized {
     }
 }
 
-impl<T: TextureWithFactory<Factory = ()>> Texture for T {}
+impl<T: TextureWithFactory<()>> Texture for T {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 
 //! A library for texture conventions.
 
-use std::fmt::{ Display, Formatter, Error };
-
 pub mod ops;
 
 /// Implemented by all images to be used with generic algorithms.
@@ -78,33 +76,18 @@ impl TextureSettings {
     }
 }
 
-/// Result of an texture creating/updating process.
-pub type TextureResult<T> = Result<T, TextureError>;
-
-/// Texture errors.
-#[derive(Debug)]
-pub enum TextureError {
-    /// The error in backend factory.
-    FactoryError(String),
-}
-
-impl Display for TextureError {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        match *self {
-            TextureError::FactoryError(ref s) => s.fmt(f)
-        }
-    }
-}
-
 /// Implemented by rgba8 textures.
 pub trait Rgba8Texture<F>: ImageSize {
+    /// The error when creating or updating texture.
+    type Error;
+
     /// Create rgba8 texture from memory.
-    fn from_memory<S: Into<[u32; 2]>>(
+    fn create<S: Into<[u32; 2]>>(
         factory: &mut F,
         memory: &[u8],
         size: S,
         settings: &TextureSettings
-    ) -> TextureResult<Self>;
+    ) -> Result<Self, Self::Error>;
 
     /// Update rgba8 texture.
     fn update<S: Into<[u32; 2]>>(
@@ -112,5 +95,5 @@ pub trait Rgba8Texture<F>: ImageSize {
         factory: &mut F,
         memory: &[u8],
         size: S,
-    ) -> TextureResult<()>;
+    ) -> Result<(), Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,7 @@
 
 //! A library for texture conventions.
 
-extern crate image;
-
 use std::fmt::{ Display, Formatter, Error };
-use std::path::Path;
-use image::{ RgbaImage, ImageError, DynamicImage };
 
 pub mod ops;
 
@@ -29,7 +25,6 @@ pub trait ImageSize {
         h
     }
 }
-
 
 /// Texture creation parameters.
 pub struct TextureSettings {
@@ -101,28 +96,13 @@ pub type TextureResult<T> = Result<T, TextureError>;
 /// An enumeration of Texture and TextureWithDevice errors.
 #[derive(Debug)]
 pub enum TextureError {
-    /// The image openinng error.
-    ImageError(ImageError),
-
-    /// The channels number error.
-    InvalidNumberOfChannels(u8),
-
     /// The error in backend factory.
     FactoryError(String),
-}
-
-impl From<ImageError> for TextureError {
-    fn from(e: ImageError) -> Self {
-        TextureError::ImageError(e)
-    }
 }
 
 impl Display for TextureError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match *self {
-            TextureError::ImageError(ref e) => e.fmt(f),
-            TextureError::InvalidNumberOfChannels(n) =>
-                format!("Invalid number of channels: {}, expected 1 or 4", n).fmt(f),
             TextureError::FactoryError(ref s) => s.fmt(f)
         }
     }
@@ -130,32 +110,6 @@ impl Display for TextureError {
 
 /// Unified interface creating/updating texture over backends.
 pub trait TextureWithFactory<F>: ImageSize + Sized {
-
-    /// Create texture from path.
-    #[inline(always)]
-    fn from_path<P: AsRef<Path>>(
-        device: &mut F,
-        path: P,
-        settings: &TextureSettings
-    ) -> TextureResult<Self> {
-        let image = try!(image::open(path));
-        let image = match image {
-            DynamicImage::ImageRgba8(image) => image,
-            image => image.to_rgba()
-        };
-        Self::from_image(device, &image, settings)
-    }
-
-    /// Create texture from RGBA image.
-    #[inline(always)]
-    fn from_image(
-        device: &mut F,
-        image: &RgbaImage,
-        settings: &TextureSettings
-    ) -> TextureResult<Self> {
-        Self::from_memory(device, image, image.width(), image.height(), 4, settings)
-    }
-
     /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
     fn from_memory(
         device: &mut F,
@@ -165,31 +119,6 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
         channels: u8,
         settings: &TextureSettings
     ) -> TextureResult<Self>;
-
-    /// Update texture from path.
-    #[inline(always)]
-    fn update_from_path<P: AsRef<Path>>(
-        &mut self,
-        device: &mut F,
-        path: P
-    ) -> TextureResult<()> {
-        let image = try!(image::open(path));
-        let image = match image {
-            DynamicImage::ImageRgba8(image) => image,
-            image => image.to_rgba()
-        };
-        self.update_from_image(device, &image)
-    }
-
-    /// Update texture from RGBA image.
-    #[inline(always)]
-    fn update_from_image(
-        &mut self,
-        device: &mut F,
-        image: &RgbaImage
-    ) -> TextureResult<()> {
-        self.update_from_memory(device, image, image.width(), image.height(), 4)
-    }
 
     /// Update texture from memory buffer. Supported only RGBA and alpha channels images.
     fn update_from_memory(
@@ -204,24 +133,6 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
 
 /// Interface for device independent backends.
 pub trait Texture: TextureWithFactory<()> + Sized {
-    /// Create texture from path.
-    #[inline(always)]
-    fn from_path<P: AsRef<Path>>(
-        path: P,
-        settings: &TextureSettings
-    ) -> TextureResult<Self> {
-        TextureWithFactory::from_path(&mut (), path, settings)
-    }
-
-    /// Create texture from RGBA image.
-    #[inline(always)]
-    fn from_image(
-        image: &RgbaImage,
-        settings: &TextureSettings
-    ) -> TextureResult<Self> {
-        TextureWithFactory::from_image(&mut (), image, settings)
-    }
-
     /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
     #[inline(always)]
     fn from_memory(
@@ -232,18 +143,6 @@ pub trait Texture: TextureWithFactory<()> + Sized {
         settings: &TextureSettings
     ) -> TextureResult<Self> {
         TextureWithFactory::from_memory(&mut (), memory, width, height, channels, settings)
-    }
-
-    /// Update texture from path.
-    #[inline(always)]
-    fn update_from_path<P: AsRef<Path>>(&mut self, path: P) -> TextureResult<()> {
-        TextureWithFactory::update_from_path(self, &mut (), path)
-    }
-
-    /// Update texture from RGBA image.
-    #[inline(always)]
-    fn update_from_image(&mut self, image: &RgbaImage) -> TextureResult<()> {
-        TextureWithFactory::update_from_image(self, &mut (), image)
     }
 
     /// Update texture from memory buffer. Supports only RGBA and alpha channels images.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,20 +111,20 @@ impl Display for TextureError {
 /// Unified interface creating/updating texture over backends.
 pub trait TextureWithFactory<F>: ImageSize + Sized {
     /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
-    fn from_memory(
+    fn from_memory<S: Into<[u32; 2]>>(
         device: &mut F,
         memory: &[u8],
-        size: [u32; 2],
+        size: S,
         channels: u8,
         settings: &TextureSettings
     ) -> TextureResult<Self>;
 
     /// Update texture from memory buffer. Supported only RGBA and alpha channels images.
-    fn update_from_memory(
+    fn update_from_memory<S: Into<[u32; 2]>>(
         &mut self,
         device: &mut F,
         memory: &[u8],
-        size: [u32; 2],
+        size: S,
         channels: u8
     ) -> TextureResult<()>;
 }
@@ -133,9 +133,9 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
 pub trait Texture: TextureWithFactory<()> + Sized {
     /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
     #[inline(always)]
-    fn from_memory(
+    fn from_memory<S: Into<[u32; 2]>>(
         memory: &[u8],
-        size: [u32; 2],
+        size: S,
         channels: u8,
         settings: &TextureSettings
     ) -> TextureResult<Self> {
@@ -144,10 +144,10 @@ pub trait Texture: TextureWithFactory<()> + Sized {
 
     /// Update texture from memory buffer. Supports only RGBA and alpha channels images.
     #[inline(always)]
-    fn update_from_memory(
+    fn update_from_memory<S: Into<[u32; 2]>>(
         &mut self,
         memory: &[u8],
-        size: [u32; 2],
+        size: S,
         channels: u8
     ) -> TextureResult<()> {
         TextureWithFactory::update_from_memory(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl TextureSettings {
 /// Result of an texture creating/updating process.
 pub type TextureResult<T> = Result<T, TextureError>;
 
-/// An enumeration of Texture and TextureWithDevice errors.
+/// Texture errors.
 #[derive(Debug)]
 pub enum TextureError {
     /// The error in backend factory.
@@ -108,23 +108,21 @@ impl Display for TextureError {
     }
 }
 
-/// Unified interface creating/updating texture over backends.
-pub trait TextureWithFactory<F>: ImageSize + Sized {
-    /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
+/// Implemented by RGBA8 textures.
+pub trait Rgba8Texture<F>: ImageSize {
+    /// Create RGBA8 texture from memory.
     fn from_memory<S: Into<[u32; 2]>>(
-        device: &mut F,
+        factory: &mut F,
         memory: &[u8],
         size: S,
-        channels: u8,
         settings: &TextureSettings
     ) -> TextureResult<Self>;
 
-    /// Update texture from memory buffer. Supported only RGBA and alpha channels images.
-    fn update_from_memory<S: Into<[u32; 2]>>(
+    /// Update RGBA8 texture.
+    fn update<S: Into<[u32; 2]>>(
         &mut self,
-        device: &mut F,
+        factory: &mut F,
         memory: &[u8],
         size: S,
-        channels: u8
     ) -> TextureResult<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ use std::fmt::{ Display, Formatter, Error };
 use std::path::Path;
 use image::{ RgbaImage, ImageError, DynamicImage };
 
+pub mod ops;
+
 /// Implemented by all images to be used with generic algorithms.
 pub trait ImageSize {
     /// Get the image size.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub enum TextureError {
     ImageError(ImageError),
 
     /// The channels number error.
-    InvalidNumberOfChannels(usize),
+    InvalidNumberOfChannels(u8),
 
     /// The error in backend factory.
     FactoryError(String),
@@ -151,16 +151,16 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
         image: &RgbaImage,
         settings: &TextureSettings
     ) -> TextureResult<Self> {
-        let width = image.width() as usize;
-        Self::from_memory(device, image, width, 4, settings)
+        Self::from_memory(device, image, image.width(), image.height(), 4, settings)
     }
 
     /// Create texture from memory buffer. Supported only RGBA and alpha channels images.
     fn from_memory(
         device: &mut F,
         memory: &[u8],
-        width: usize,
-        channels: usize,
+        width: u32,
+        height: u32,
+        channels: u8,
         settings: &TextureSettings
     ) -> TextureResult<Self>;
 
@@ -186,8 +186,7 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
         device: &mut F,
         image: &RgbaImage
     ) -> TextureResult<()> {
-        let width = image.width() as usize;
-        self.update_from_memory(device, image, width, 4)
+        self.update_from_memory(device, image, image.width(), image.height(), 4)
     }
 
     /// Update texture from memory buffer. Supported only RGBA and alpha channels images.
@@ -195,8 +194,9 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
         &mut self,
         device: &mut F,
         memory: &[u8],
-        width: usize,
-        channels: usize
+        width: u32,
+        height: u32,
+        channels: u8
     ) -> TextureResult<()>;
 }
 
@@ -224,11 +224,12 @@ pub trait Texture: TextureWithFactory<()> + Sized {
     #[inline(always)]
     fn from_memory(
         memory: &[u8],
-        width: usize,
-        channels: usize,
+        width: u32,
+        height: u32,
+        channels: u8,
         settings: &TextureSettings
     ) -> TextureResult<Self> {
-        TextureWithFactory::from_memory(&mut (), memory, width, channels, settings)
+        TextureWithFactory::from_memory(&mut (), memory, width, height, channels, settings)
     }
 
     /// Update texture from path.
@@ -248,10 +249,12 @@ pub trait Texture: TextureWithFactory<()> + Sized {
     fn update_from_memory(
         &mut self,
         memory: &[u8],
-        width: usize,
-        channels: usize
+        width: u32,
+        height: u32,
+        channels: u8
     ) -> TextureResult<()> {
-        TextureWithFactory::update_from_memory(self, &mut (), memory, width, channels)
+        TextureWithFactory::update_from_memory(
+            self, &mut (), memory, width, height, channels)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,7 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
     fn from_memory(
         device: &mut F,
         memory: &[u8],
-        width: u32,
-        height: u32,
+        size: [u32; 2],
         channels: u8,
         settings: &TextureSettings
     ) -> TextureResult<Self>;
@@ -125,8 +124,7 @@ pub trait TextureWithFactory<F>: ImageSize + Sized {
         &mut self,
         device: &mut F,
         memory: &[u8],
-        width: u32,
-        height: u32,
+        size: [u32; 2],
         channels: u8
     ) -> TextureResult<()>;
 }
@@ -137,12 +135,11 @@ pub trait Texture: TextureWithFactory<()> + Sized {
     #[inline(always)]
     fn from_memory(
         memory: &[u8],
-        width: u32,
-        height: u32,
+        size: [u32; 2],
         channels: u8,
         settings: &TextureSettings
     ) -> TextureResult<Self> {
-        TextureWithFactory::from_memory(&mut (), memory, width, height, channels, settings)
+        TextureWithFactory::from_memory(&mut (), memory, size, channels, settings)
     }
 
     /// Update texture from memory buffer. Supports only RGBA and alpha channels images.
@@ -150,12 +147,11 @@ pub trait Texture: TextureWithFactory<()> + Sized {
     fn update_from_memory(
         &mut self,
         memory: &[u8],
-        width: u32,
-        height: u32,
+        size: [u32; 2],
         channels: u8
     ) -> TextureResult<()> {
         TextureWithFactory::update_from_memory(
-            self, &mut (), memory, width, height, channels)
+            self, &mut (), memory, size, channels)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ pub trait ImageSize {
 
 /// Texture creation parameters.
 pub struct TextureSettings {
-    flip_vertical: bool,
     convert_gamma: bool,
     /// Compress on GPU.
     compress: bool,
@@ -40,21 +39,10 @@ impl TextureSettings {
     /// Create default settings.
     pub fn new() -> TextureSettings {
         TextureSettings {
-            flip_vertical: false,
             convert_gamma: false,
             compress: false,
             generate_mipmap: false,
         }
-    }
-
-    /// Gets whether to flip vertical.
-    pub fn get_flip_vertical(&self) -> bool { self.flip_vertical }
-    /// Sets flip vertical.
-    pub fn set_flip_vertical(&mut self, val: bool) { self.flip_vertical = val; }
-    /// Sets flip vertical.
-    pub fn flip_vertical(mut self, val: bool) -> Self {
-        self.set_flip_vertical(val);
-        self
     }
 
     /// Gets wheter to convert gamma, treated as sRGB color space.
@@ -108,9 +96,9 @@ impl Display for TextureError {
     }
 }
 
-/// Implemented by RGBA8 textures.
+/// Implemented by rgba8 textures.
 pub trait Rgba8Texture<F>: ImageSize {
-    /// Create RGBA8 texture from memory.
+    /// Create rgba8 texture from memory.
     fn from_memory<S: Into<[u32; 2]>>(
         factory: &mut F,
         memory: &[u8],
@@ -118,7 +106,7 @@ pub trait Rgba8Texture<F>: ImageSize {
         settings: &TextureSettings
     ) -> TextureResult<Self>;
 
-    /// Update RGBA8 texture.
+    /// Update rgba8 texture.
     fn update<S: Into<[u32; 2]>>(
         &mut self,
         factory: &mut F,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -16,3 +16,20 @@ pub fn flip_vertical(memory: &[u8], size: [u32; 2], channels: u8) -> Vec<u8> {
     }
     res
 }
+
+/// Converts from alpha to rgba8.
+pub fn alpha_to_rgba8(memory: &[u8], size: [u32; 2]) -> Vec<u8> {
+    let (width, height) = (size[0] as usize, size[1] as usize);
+    let capacity = width * height * 4;
+    let stride = width;
+    let mut res = Vec::with_capacity(capacity);
+    for y in (0..height) {
+        for x in (0..width) {
+            res.push(0);
+            res.push(0);
+            res.push(0);
+            res.push(memory[x + y * stride]);
+        }
+    }
+    res
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,17 @@
+//! Image operations for textures.
+
+/// Flips the image vertically.
+pub fn flip_vertical(memory: &[u8], width: u32, height: u32, channels: u8) -> Vec<u8> {
+    let (width, height, channels) = (width as usize, height as usize, channels as usize);
+    let mut res = vec![0; width * height];
+    let stride = width * channels;
+    for y in (0..height) {
+        for x in (0..width) {
+            for c in (0..channels) {
+                res[(c + x * channels + (height - 1 - y) * stride) as usize] =
+                    memory[(c + x * channels + y * stride) as usize];
+            }
+        }
+    }
+    res
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,8 +1,9 @@
 //! Image operations for textures.
 
 /// Flips the image vertically.
-pub fn flip_vertical(memory: &[u8], width: u32, height: u32, channels: u8) -> Vec<u8> {
-    let (width, height, channels) = (width as usize, height as usize, channels as usize);
+pub fn flip_vertical(memory: &[u8], size: [u32; 2], channels: u8) -> Vec<u8> {
+    let (width, height, channels) = (size[0] as usize, size[1] as usize,
+        channels as usize);
     let mut res = vec![0; width * height];
     let stride = width * channels;
     for y in (0..height) {


### PR DESCRIPTION
Based on https://github.com/PistonDevelopers/texture/pull/24, but simplified.

* Added `TextureSettings` (taken from gfx_texture, but with no `flip_vertical`
* Added `Rgba8Texture`, which takes factory as argument
* Added some helper operations
* Bumped to 0.2.0