### PR TITLE
Add an offset argument to the UpdateTexture::update method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston-texture"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>"
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,14 +171,20 @@ pub trait UpdateTexture<F>: ImageSize + Sized {
     /// The error when updating texture.
     type Error;
 
-    /// Update texture.
-    fn update<S: Into<[u32; 2]>>(
+    /// Update the texture.
+    ///
+    /// The `offset` and `size` arguments represent the position and dimensions of the sub-section
+    /// of the texture that is to be updated with the given `memory`.
+    fn update<O, S>(
         &mut self,
         factory: &mut F,
         format: Format,
         memory: &[u8],
+        offset: O,
         size: S,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<(), Self::Error>
+        where O: Into<[u32; 2]>,
+              S: Into<[u32; 2]>;
 }
 
 /// Sampling filter


### PR DESCRIPTION
Currently the `UpdateTexture::update` method only seems to allow for specifying the `size` of the subsection that should be updated, and not its offset.

This PR adds an argument to the method to allow for users to specify the offset of the texture subsection which is to be updated.

This is a breaking change. An update is prepared for `gfx_texture` at PistonDevelopers/gfx_texture#88. I'm unsure if there are any other piston crates implementing the trait.

cc @bvssvni 